### PR TITLE
ansible実行用venvを公開する

### DIFF
--- a/.bootstrap/ansible.sh
+++ b/.bootstrap/ansible.sh
@@ -9,7 +9,23 @@ SUDO='sudo -E'
 # Not use sudo if root
 [ "$(id -u)" = 0 ] && SUDO=
 
-$SUDO apt update
-$SUDO env DEBIAN_FRONTEND=noninteractive apt install -y \
-      software-properties-common python3-pip python3-setuptools
-$SUDO pip3 install ansible pywinrm
+if [ -e /etc/os-release ]; then
+  . /etc/os-release
+fi
+
+if [ "$ID" = "ubuntu" ]; then
+  # Install requirements
+  $SUDO apt update && $SUDO env DEBIAN_FRONTEND=noninteractive apt install -y python3
+  # Download ansible venv
+  URL=https://dotfiles.kaichan.info/venv
+  venv_name="${ID}-${VERSION_ID}-ansible-venv.tar.gz"
+  venv_location=/opt/ansible-venv
+  sudo mkdir -p "$venv_location"
+  curl -sSL "${URL}/${venv_name}" | tar zxv --directory "$venv_location"
+else
+  ## Other than Ubuntu
+  $SUDO apt update
+  $SUDO env DEBIAN_FRONTEND=noninteractive apt install -y \
+        software-properties-common python3-pip python3-setuptools
+  $SUDO pip3 install ansible pywinrm
+fi

--- a/.bootstrap/ansible.sh
+++ b/.bootstrap/ansible.sh
@@ -21,7 +21,7 @@ if [ "$ID" = "ubuntu" ]; then
   venv_name="${ID}-${VERSION_ID}-ansible-venv.tar.gz"
   venv_location=/opt/ansible-venv
   $SUDO mkdir -p "$venv_location"
-  curl -sSL "${URL}/${venv_name}" | $SUDO tar zxv --directory "$venv_location"
+  curl -sSL "${URL}/${venv_name}" | $SUDO tar zx --directory "$venv_location"
 else
   ## Other than Ubuntu
   $SUDO apt update

--- a/.bootstrap/ansible.sh
+++ b/.bootstrap/ansible.sh
@@ -20,8 +20,8 @@ if [ "$ID" = "ubuntu" ]; then
   URL=https://dotfiles.kaichan.info/venv
   venv_name="${ID}-${VERSION_ID}-ansible-venv.tar.gz"
   venv_location=/opt/ansible-venv
-  sudo mkdir -p "$venv_location"
-  curl -sSL "${URL}/${venv_name}" | tar zxv --directory "$venv_location"
+  $SUDO mkdir -p "$venv_location"
+  curl -sSL "${URL}/${venv_name}" | $SUDO tar zxv --directory "$venv_location"
 else
   ## Other than Ubuntu
   $SUDO apt update

--- a/.bootstrap/ansible.sh
+++ b/.bootstrap/ansible.sh
@@ -15,7 +15,7 @@ fi
 
 if [ "$ID" = "ubuntu" ]; then
   # Install requirements
-  $SUDO apt update && $SUDO env DEBIAN_FRONTEND=noninteractive apt install -y python3
+  $SUDO apt update && $SUDO env DEBIAN_FRONTEND=noninteractive apt install -y python3 curl
   # Download ansible venv
   URL=https://dotfiles.kaichan.info/venv
   venv_name="${ID}-${VERSION_ID}-ansible-venv.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Run the bootstrap script
         run: bash -e bootstrap.sh
       - name: Apply ansible playbook
-        run: cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
+        run: . /opt/ansible-venv/bin/activate && cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
       - name: Apply ansible playbook again
-        run: cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
+        run: . /opt/ansible-venv/bin/activate && cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
   container:
     runs-on: ubuntu-20.04
     strategy:
@@ -53,11 +53,11 @@ jobs:
       - name: Apply ansible playbook
         run: >-
           docker exec target bash -c
-          "cd ansible && ansible-playbook -i localhost, test.yml"
+          ". /opt/ansible-venv/bin/activate && cd ansible && ansible-playbook -i localhost, test.yml"
       - name: Apply ansible playbook again
         run: >-
           docker exec target bash -c
-          "cd ansible && ansible-playbook -i localhost, test.yml"
+          ". /opt/ansible-venv/bin/activate && cd ansible && ansible-playbook -i localhost, test.yml"
       - name: Kill the target container
         run: docker rm --force target
   wsl:
@@ -84,6 +84,6 @@ jobs:
       - name: Run the bootstrap script
         run: ./bootstrap.sh
       - name: Apply ansible playbook
-        run: cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
+        run: . /opt/ansible-venv/bin/activate && cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
       - name: Apply ansible playbook again
-        run: cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml
+        run: . /opt/ansible-venv/bin/activate && cd ~/dotfiles/ansible && ansible-playbook -i localhost, test.yml

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          cname: dotfiles.kaichan.info
           enable_jekyll: true
           force_orphan: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,3 +31,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          enable_jekyll: true
+          force_orphan: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        image: ['ubuntu:20.04', 'ubuntu:18.04']
+        image: ['ubuntu-20.04', 'ubuntu-18.04']
     steps:
       - uses: actions/checkout@v2
       - name: Create venv in docker
         run: |
           set -eux
+          image=$(echo '${{ matrix.image }}' | tr '-' ':')
           docker run -e LANG=C.UTF-8 -v "$PWD:/root/dotfiles" -w /root/dotfiles \
-            ${{ matrix.image }} ./ci/create_ansible_venv.sh
+            "$image" ./ci/create_ansible_venv.sh
       - name: Upload the venv archive as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,3 +24,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download venv archives
         uses: actions/download-artifact@v2
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: github pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  create-venv:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create venv
+        run: sudo ./ci/create_ansible_venv.sh
+      - name: Upload the venv archive as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: 'docs/*.tar.gz'
+  deploy:
+    runs-on: ubuntu-20.04
+    needs: create-venv
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download venv archives
+        uses: actions/download-artifact@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   create-venv:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
       - name: Create venv
@@ -16,7 +19,7 @@ jobs:
       - name: Upload the venv archive as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ubuntu-20.04
+          name: ${{ matrix.os }}
           path: '*.tar.gz'
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,18 +8,20 @@ on:
 
 jobs:
   create-venv:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        image: ['ubuntu:20.04', 'ubuntu:18.04']
     steps:
       - uses: actions/checkout@v2
-      - name: Create venv
-        run: sudo ./ci/create_ansible_venv.sh
+      - name: Create venv in docker
+        run: |
+          set -eux
+          docker run -v "$PWD:/root/dotfiles" -w /root/dotfiles ${{ matrix.image }} ./ci/create_ansible_venv.sh
       - name: Upload the venv archive as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.os }}
+          name: ${{ matrix.image }}
           path: '*.tar.gz'
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,8 +3,10 @@ name: github pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'ci/create_ansible_venv.sh'
+      - '.github/workflows/gh-pages.yml'
 
 jobs:
   create-venv:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Create venv in docker
         run: |
           set -eux
-          docker run -v "$PWD:/root/dotfiles" -w /root/dotfiles ${{ matrix.image }} ./ci/create_ansible_venv.sh
+          docker run -e LANG=C.UTF-8 -v "$PWD:/root/dotfiles" -w /root/dotfiles \
+            ${{ matrix.image }} ./ci/create_ansible_venv.sh
       - name: Upload the venv archive as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download venv archives
         uses: actions/download-artifact@v2
+        with:
+          path: docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Upload the venv archive as artifact
         uses: actions/upload-artifact@v2
         with:
-          path: 'docs/*.tar.gz'
+          name: ubuntu-20.04
+          path: '*.tar.gz'
   deploy:
     runs-on: ubuntu-20.04
     needs: create-venv
@@ -25,7 +26,11 @@ jobs:
       - name: Download venv archives
         uses: actions/download-artifact@v2
         with:
-          path: docs
+          path: /tmp
+      - name: Move archives into docs directory
+        run: |
+          mkdir -p docs/venv
+          find /tmp -type f -name "*.tar.gz" | xargs mv -t docs/venv
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/ansible/group_vars/all/00_runtime.yml
+++ b/ansible/group_vars/all/00_runtime.yml
@@ -1,2 +1,7 @@
 is_windows: "{{ ansible_facts.os_family == 'Windows' }}"
-is_wsl: "{{ ansible_facts.kernel is search('microsoft', ignorecase=True) }}"
+is_container: "{{ '/.dockerenv' is exists }}"
+is_wsl: >-
+  {{
+    (ansible_facts.kernel is search('microsoft', ignorecase=True))
+    and (not is_container)
+  }}

--- a/ansible/roles/dev_ubuntu/tasks/main.yml
+++ b/ansible/roles/dev_ubuntu/tasks/main.yml
@@ -1,6 +1,18 @@
 - name: Validate the role precondition
   tags: [validation]
   import_tasks: validate_precondition.yml
+- name: Update apt cache
+  tags: [package]
+  become: yes
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+- name: Install ansible module requirements
+  tags: [package]
+  become: yes
+  apt:
+    name:
+      - gpg  # for ansible.builtin.apt_key
 - name: Configure pipenv
   # Create a virtualenv for pipenv in the project directory
   tags: [config]
@@ -39,12 +51,6 @@
   apt_repository:
     repo: deb https://download.docker.com/linux/ubuntu {{ ansible_facts.distribution_release }} stable
     state: present
-- name: Update apt cache
-  tags: [package]
-  become: yes
-  apt:
-    update_cache: yes
-    cache_valid_time: 3600
 - name: Uninstall needless packages
   tags: [package]
   become: yes

--- a/ci/create_ansible_venv.sh
+++ b/ci/create_ansible_venv.sh
@@ -5,7 +5,7 @@
 
 set -eu
 
-DIR=$(dirname "$(readlink -e "$0")")
+cwd="$PWD"
 
 ## Install prerequisites
 sed -i.bak "s@http://archive.ubuntu.com/ubuntu/@mirror://mirrors.ubuntu.com/mirrors.txt@g" /etc/apt/sources.list
@@ -33,4 +33,4 @@ mv "$venv_location" "$TARGET_LOCATION"
 cd "$TARGET_LOCATION"
 find . -name "*.pyc" -print0 | xargs -0 --no-run-if-empty -- rm
 grep "$venv_location" -RIl | xargs --no-run-if-empty -- sed -i "s@${venv_location}@${TARGET_LOCATION}@g"
-tar zcf "${DIR}/docs/${NAME}-${VERSION_ID}-ansible-venv.tar.gz" .
+tar zcf "${cwd}/docs/${NAME}-${VERSION_ID}-ansible-venv.tar.gz" .

--- a/ci/create_ansible_venv.sh
+++ b/ci/create_ansible_venv.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+### Create a virtualenv to run ansible playbook by poetry and
+### archive it to share created virtualenv.
+
+set -eu
+
+DIR=$(dirname "$(readlink -e "$0")")
+
+## Install prerequisites
+sed -i.bak "s@http://archive.ubuntu.com/ubuntu/@mirror://mirrors.ubuntu.com/mirrors.txt@g" /etc/apt/sources.list
+apt update && apt install -y ca-certificates
+apt update && apt install -y curl python3 python3-dev python3-distutils
+
+## Install poetry
+export POETRY_HOME=/opt/poetry
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+
+# shellcheck disable=SC1090
+. "${POETRY_HOME}/env"
+
+## Install dependent packages into venv
+cd ansible
+poetry install --no-dev
+
+## Move venv into a fixed location
+TARGET_LOCATION=/opt/ansible-venv
+venv_location=$(poetry env info -p)
+mv "$venv_location" "$TARGET_LOCATION"
+
+## Archive the venv
+. "/etc/os-release"
+cd "$TARGET_LOCATION"
+find . -name "*.pyc" -print0 | xargs -0 --no-run-if-empty -- rm
+grep "$venv_location" -RIl | xargs --no-run-if-empty -- sed -i "s@${venv_location}@${TARGET_LOCATION}@g"
+tar zcf "${DIR}/docs/${NAME}-${VERSION_ID}-ansible-venv.tar.gz" .

--- a/ci/create_ansible_venv.sh
+++ b/ci/create_ansible_venv.sh
@@ -34,4 +34,4 @@ mv "$venv_location" "$TARGET_LOCATION"
 cd "$TARGET_LOCATION"
 find . -name "*.pyc" -print0 | xargs -0 --no-run-if-empty -- rm
 grep "$venv_location" -RIl | xargs --no-run-if-empty -- sed -i "s@${venv_location}@${TARGET_LOCATION}@g"
-tar zcf "${cwd}/docs/${NAME}-${VERSION_ID}-ansible-venv.tar.gz" .
+tar zcf "${cwd}/${ID}-${VERSION_ID}-ansible-venv.tar.gz" .

--- a/ci/create_ansible_venv.sh
+++ b/ci/create_ansible_venv.sh
@@ -21,6 +21,7 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 
 ## Install dependent packages into venv
 cd ansible
+poetry env use /usr/bin/python3
 poetry install --no-dev
 
 ## Move venv into a fixed location

--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,1 +1,0 @@
-*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,0 +1,1 @@
+*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-dotfiles.kaichan.info


### PR DESCRIPTION
ansibleのインストールをpipでするととても時間がかかるので、あらかじめインストール済みの
venvをダウンロードして展開するだけでOKにする。
が、当然ながらあらかじめ実行する環境にあわせて複数種類のvenvを作っとかないといけない。
GitHubActionsの出番だ。
