### PR TITLE
dotterでシンボリックリンクを管理する

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -11,7 +11,10 @@ depends = []
 "configs/.textlintrc" = "~/.textlintrc"
 "configs/.prh.yml" = "~/.prh.yml"
 "configs/.tmux.conf" = "~/.tmux.conf"
-"configs/navi/config.yaml" = "~/.config/navi/config.yaml"
+"configs/dot.ahk" = { target = "~/dot.ahk", type = "symbolic", if = '(eq dotter.os "windows")' }
+"configs/dot.nodoka" = { target = "~/dot.nodoka", type = "symbolic", if = '(eq dotter.os "windows")' }
+"configs/navi/config.yaml" = { target = "~/.config/navi/config.yaml", type = "symbolic", if = '(ne dotter.os "windows")' }
+"configs/navi/config.win.yaml" = {target = "~/AppData/Roaming/navi/config.yaml", type = "symbolic", if = '(eq dotter.os "windows")' }
 "configs/navi/cheats" = { target = "~/.local/share/navi/cheats/dotfiles", type = "symbolic", recurse = false }
 "configs/bat/config" = "~/.config/bat/config"
 "configs/pet/snippet.toml" = "~/.config/pet/snippet.toml"
@@ -19,10 +22,11 @@ depends = []
 "configs/pscore_profile.ps1" = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
 "configs/vscode/settings.json" = "~/.config/Code/User/settings.json"
 "configs/vscode/keybindings.json" = "~/.config/Code/User/keybindings.json"
-"configs/starship.linux.toml" = "~/.config/starship.toml"
+"configs/starship.linux.toml" = { target = "~/.config/starship.toml", type = "symbolic", if = '(ne dotter.os "windows")' }
+"configs/starship.win.toml" =  { target = "~/.config/starship.toml", type = "symbolic", if = '(eq dotter.os "windows")' }
 "configs/.wezterm.lua" = "~/.wezterm.lua"
 "configs/git/hooks" = { target = "~/.config/git/hooks", type = "symbolic", recurse = false }
-"configs/xkb" = { target = "~/.config/xkb", type = "symbolic", recurse = false }
+"configs/xkb" = { target = "~/.config/xkb", type = "symbolic", recurse = false, if = '(eq dotter.os "unix")' }
 "utils" = { target = "~/utils", type = "symbolic", recurse = false }
 
 [default.variables]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -22,7 +22,7 @@ depends = []
 "configs/starship.linux.toml" = "~/.config/starship.toml"
 "configs/.wezterm.lua" = "~/.wezterm.lua"
 "configs/git/hooks" = { target = "~/.config/git/hooks", type = "symbolic", recurse = false }
-"configs/xkb" = { target = ".config/xkb", type = "symbolic", recurse = false }
+"configs/xkb" = { target = "~/.config/xkb", type = "symbolic", recurse = false }
 "utils" = { target = "~/utils", type = "symbolic", recurse = false }
 
 [default.variables]

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -11,19 +11,15 @@ depends = []
 "configs/.textlintrc" = "~/.textlintrc"
 "configs/.prh.yml" = "~/.prh.yml"
 "configs/.tmux.conf" = "~/.tmux.conf"
-"configs/navi/config.win.yaml" = "~/AppData/Roaming/navi/config.yaml"
-"configs/navi/cheats" = { target = "~/AppData/Roaming/navi/cheats/dotfiles", type = "symbolic", recurse = false }
-"configs/bat/config" = "~/AppData/Roaming/bat/config"
-"configs/dot.ahk" = "~/dot.ahk"
-"configs/dot.nodoka" = "~/dot.nodoka"
-"configs/pet/snippet.toml" = "~/AppData/Roaming/pet/snippet.toml"
-"configs/wt/settings.json" = "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json"
-"configs/profile.ps1" = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
-"configs/ps_alias.ps1" = "~/Documents/WindowsPowerShell/ps_alias.ps1"
-"configs/pscore_profile.ps1" = "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
-"configs/vscode/settings.json" = "~/AppData/Roaming/Code/User/settings.json"
-"configs/vscode/keybindings.json" = "~/AppData/Roaming/Code/User/keybindings.json"
-"configs/starship.win.toml" = "~/.config/starship.toml"
+"configs/navi/config.yaml" = "~/.config/navi/config.yaml"
+"configs/navi/cheats" = { target = "~/.local/share/navi/cheats/dotfiles", type = "symbolic", recurse = false }
+"configs/bat/config" = "~/.config/bat/config"
+"configs/pet/snippet.toml" = "~/.config/pet/snippet.toml"
+"configs/ps_alias.ps1" = "~/.config/powershell/ps_alias.ps1"
+"configs/pscore_profile.ps1" = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
+"configs/vscode/settings.json" = "~/.config/Code/User/settings.json"
+"configs/vscode/keybindings.json" = "~/.config/Code/User/keybindings.json"
+"configs/starship.linux.toml" = "~/.config/starship.toml"
 "configs/.wezterm.lua" = "~/.wezterm.lua"
 "configs/git/hooks" = { target = "~/.config/git/hooks", type = "symbolic", recurse = false }
 "configs/xkb" = { target = ".config/xkb", type = "symbolic", recurse = false }

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,0 +1,32 @@
+[helpers]
+
+[default]
+depends = []
+
+[default.files]
+"configs/.bash_aliases" = "~/.bash_aliases"
+"configs/.bashrc" = "~/.bashrc"
+"configs/.bash.d" = { target = "~/.bash.d", type = "symbolic", recurse = false }
+"configs/.profile" = "~/.profile"
+"configs/.textlintrc" = "~/.textlintrc"
+"configs/.prh.yml" = "~/.prh.yml"
+"configs/.tmux.conf" = "~/.tmux.conf"
+"configs/navi/config.win.yaml" = "~/AppData/Roaming/navi/config.yaml"
+"configs/navi/cheats" = { target = "~/AppData/Roaming/navi/cheats/dotfiles", type = "symbolic", recurse = false }
+"configs/bat/config" = "~/AppData/Roaming/bat/config"
+"configs/dot.ahk" = "~/dot.ahk"
+"configs/dot.nodoka" = "~/dot.nodoka"
+"configs/pet/snippet.toml" = "~/AppData/Roaming/pet/snippet.toml"
+"configs/wt/settings.json" = "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json"
+"configs/profile.ps1" = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+"configs/ps_alias.ps1" = "~/Documents/WindowsPowerShell/ps_alias.ps1"
+"configs/pscore_profile.ps1" = "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+"configs/vscode/settings.json" = "~/AppData/Roaming/Code/User/settings.json"
+"configs/vscode/keybindings.json" = "~/AppData/Roaming/Code/User/keybindings.json"
+"configs/starship.win.toml" = "~/.config/starship.toml"
+"configs/.wezterm.lua" = "~/.wezterm.lua"
+"configs/git/hooks" = { target = "~/.config/git/hooks", type = "symbolic", recurse = false }
+"configs/xkb" = { target = ".config/xkb", type = "symbolic", recurse = false }
+"utils" = { target = "~/utils", type = "symbolic", recurse = false }
+
+[default.variables]

--- a/.dotter/windows.toml
+++ b/.dotter/windows.toml
@@ -1,0 +1,17 @@
+[default.files]
+"configs/navi/config.yaml" = ""
+"configs/navi/config.win.yaml" = "~/AppData/Roaming/navi/config.yaml"
+"configs/navi/cheats" = { target = "~/AppData/Roaming/navi/cheats/dotfiles", type = "symbolic", recurse = false }
+"configs/bat/config" = "~/AppData/Roaming/bat/config"
+"configs/dot.ahk" = "~/dot.ahk"
+"configs/dot.nodoka" = "~/dot.nodoka"
+"configs/pet/snippet.toml" = "~/AppData/Roaming/pet/snippet.toml"
+"configs/wt/settings.json" = "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json"
+"configs/profile.ps1" = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+"configs/ps_alias.ps1" = "~/Documents/PowerShell/ps_alias.ps1"
+"configs/pscore_profile.ps1" = "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+"configs/vscode/settings.json" = "~/AppData/Roaming/Code/User/settings.json"
+"configs/vscode/keybindings.json" = "~/AppData/Roaming/Code/User/keybindings.json"
+"configs/starship.linux.toml" = ""
+"configs/starship.win.toml" = "~/.config/starship.toml"
+"configs/xkb" = ""

--- a/.dotter/windows.toml
+++ b/.dotter/windows.toml
@@ -1,10 +1,6 @@
 [default.files]
-"configs/navi/config.yaml" = ""
-"configs/navi/config.win.yaml" = "~/AppData/Roaming/navi/config.yaml"
 "configs/navi/cheats" = { target = "~/AppData/Roaming/navi/cheats/dotfiles", type = "symbolic", recurse = false }
 "configs/bat/config" = "~/AppData/Roaming/bat/config"
-"configs/dot.ahk" = "~/dot.ahk"
-"configs/dot.nodoka" = "~/dot.nodoka"
 "configs/pet/snippet.toml" = "~/AppData/Roaming/pet/snippet.toml"
 "configs/wt/settings.json" = "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json"
 "configs/profile.ps1" = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
@@ -12,6 +8,3 @@
 "configs/pscore_profile.ps1" = "~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
 "configs/vscode/settings.json" = "~/AppData/Roaming/Code/User/settings.json"
 "configs/vscode/keybindings.json" = "~/AppData/Roaming/Code/User/keybindings.json"
-"configs/starship.linux.toml" = ""
-"configs/starship.win.toml" = "~/.config/starship.toml"
-"configs/xkb" = ""

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # なんかGitHub Codespacesに勝手に作られてたディレクトリ
 pythonenv3.8/
+
+# dotter
+.dotter/local.toml
+.dotter/cache.toml

--- a/configs/ps_alias.ps1
+++ b/configs/ps_alias.ps1
@@ -127,6 +127,7 @@ $tool_hash = @{
   head = @();
   sed = @();
   tail = @();
+  vim = @();
 }
 $tool_hash.Keys | ForEach-Object {
   ## エイリアスがあれば削除する
@@ -136,7 +137,15 @@ $tool_hash.Keys | ForEach-Object {
     $name = $MyInvocation.MyCommand.Name  # 関数名を取得する
     $exe = "${GIT_DIR}\usr\bin\${name}.exe"
     $opts = $tool_hash[$name]
-    $input | & $exe @opts $args
+    $has_input = $input.MoveNext()
+    # 標準入力のあるなしで分岐
+    if ($has_input) {
+      $input.Reset() # reset an enumerator position to the beginning
+      $input | &$exe @opts $args
+    } else {
+      # no input
+      &$exe @opts $args
+    }
   }
 }
 

--- a/configs/vscode/settings.json
+++ b/configs/vscode/settings.json
@@ -8,6 +8,7 @@
   // ファイル自動保存設定
   "files.autoSave": "afterDelay",
   "editor.formatOnSave": false, // 保存時の自動フォーマット
+  "editor.minimap.enabled": false,
   "files.insertFinalNewline": true, // ファイル末尾を常に改行する
   // ファイルを自動保存する遅延時間（ミリ秒）
   "files.autoSaveDelay": 500,


### PR DESCRIPTION
[dotter](https://github.com/SuperCuber/dotter)を使うと、シンボリックリンクをyaml形式の設定ファイルで管理できる。
Linux系とWindows系で2つのシンボリックリンク作成スクリプトを作ってもいいのだが、dotterを使えばクロスプラットフォームな設定ファイルだけでよくなる。

dotter自体は軽量なバイナリなのでダウンロードするだけで使えるようになる。簡単なテンプレート機能もあるので、現在プラットフォームで分けている設定ファイルを1つにまとめることもできそう。